### PR TITLE
fix: old stream should not be live

### DIFF
--- a/old.js
+++ b/old.js
@@ -1,6 +1,7 @@
 var toPull   = require('stream-to-pull-stream')
 
 module.exports = function read(db, opts) {
+  opts.live = false;
   return toPull.read1(db.createReadStream(opts))
 }
 


### PR DESCRIPTION
in my case `{sync:true}` was never pushed, because the old stream had the same option as the live stream.